### PR TITLE
Add Portfolio Link with Icon to Founder Card

### DIFF
--- a/website3.0/pages/TeamsPage.js
+++ b/website3.0/pages/TeamsPage.js
@@ -5,8 +5,8 @@ import Image from 'next/image';
 
 //Importing FontAwesome for Icons
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGithub, faLinkedin } from "@fortawesome/free-brands-svg-icons";
-import { faHeart } from "@fortawesome/free-solid-svg-icons";
+import { faGithub, faLinkedin } from "@fortawesome/free-brands-svg-icons"; // Import the Github and linkedin icon
+import { faHeart } from "@fortawesome/free-solid-svg-icons"; // Import the Heart icon
 import { faLink } from '@fortawesome/free-solid-svg-icons'; // Import the link icon
 
 


### PR DESCRIPTION
closes #1382 

**Description:**
This pull request enhances the team page by replacing the GitHub icon in the founder's card with a portfolio icon. The new icon directly links to the founder’s portfolio, offering a more personalized and professional connection. This change provides users with quick access to the founder's portfolio, showcasing their work and projects.

**Changes Implemented:**
- Replaced the GitHub icon in the founder card with a portfolio icon.
- Updated the link to point to the founder's portfolio instead of GitHub.
- Ensured the new icon and link follow the existing style and design of the page.

@mdazfar2 review and merge my pull request