### PR TITLE
Remove gradient line from How It Works section

### DIFF
--- a/website3.0/components/homepage/HowItWorksSection.js
+++ b/website3.0/components/homepage/HowItWorksSection.js
@@ -69,8 +69,6 @@ function HowItWorksSection({ theme, tryItNowHref = "/devopsforum" }) {
         </div>
 
         <div className="relative mt-12">
-          <div className="hidden lg:block absolute top-20 left-[17%] right-[17%] h-[2px] bg-gradient-to-r from-cyan-400/70 via-sky-400/70 to-emerald-400/70"></div>
-
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-5 lg:gap-7">
             {steps.map((step, index) => (
               <div


### PR DESCRIPTION
## Description
There was a line showing up in "How it works" section. This line disrupts the user experience.

<br/>



## Related Issues
Closes #1508 


<br/>

## Screenshots 
<img width="2701" height="1067" alt="image" src="https://github.com/user-attachments/assets/7151c142-ebb1-424b-b16d-4dd92ed330b8" />
No line visible.
