### PR TITLE
Add GitHub Actions workflow for labeling issues gssoc'26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -47,3 +47,10 @@ body:
 
         - label: 'I am willing to work on this issue (optional)'
           required: false
+
+  - type: checkboxes
+    attributes:
+      label: "GSSoC Participation"
+      options:
+        - label: "I am a GSSoC'26 contributor"
+          required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -41,3 +41,10 @@ body:
 
         - label: "Soon, I'll complete it and create a Pull Request."
         - label: "I'm a beginner in DevOps, but I'll try to contribute the best resources with hands-on experience."
+
+  - type: checkboxes
+    attributes:
+      label: "GSSoC Participation"
+      options:
+        - label: "I am a GSSoC'26 contributor"
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -30,3 +30,10 @@ body:
 
         - label: 'I am willing to work on this issue (optional)'
           required: false
+
+  - type: checkboxes
+    attributes:
+      label: "GSSoC Participation"
+      options:
+        - label: "I am a GSSoC'26 contributor"
+          required: false

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,0 +1,55 @@
+name: "General Issue"
+description: "Open a general issue with required details"
+title: "[ISSUE]: "
+labels: []
+body:
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Describe your issue"
+      description: "Explain clearly what the issue is"
+      placeholder: "Write here..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected behavior"
+      description: "What should happen?"
+      placeholder: "Describe expected result"
+    validations:
+      required: false
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "Steps to reproduce"
+      description: "How can we reproduce this issue?"
+      placeholder: |
+        1. Go to...
+        2. Click...
+        3. Error occurs
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: "Environment"
+      placeholder: "Windows / Linux / Browser / Version"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: gssoc
+    attributes:
+      label: "GSSoC Participation"
+      options:
+        - label: 'I have read the [Contributing Guidelines](https://github.com/mdazfar2/HelpOps-Hub/blob/main/CONTRIBUTING.md)'
+          required: true
+          
+        - label: "I am a GSSoC'26 contributor"
+        - label: "I am willing to work on this issue"
+        

--- a/.github/ISSUE_TEMPLATE/project.yml
+++ b/.github/ISSUE_TEMPLATE/project.yml
@@ -36,3 +36,10 @@ body:
 
         - label: 'I am willing to work on this issue (optional)'
           required: false
+
+  - type: checkboxes
+    attributes:
+      label: "GSSoC Participation"
+      options:
+        - label: "I am a GSSoC'26 contributor"
+          required: false

--- a/.github/workflows/gssoc.yml
+++ b/.github/workflows/gssoc.yml
@@ -11,47 +11,49 @@ jobs:
       issues: write
 
     steps:
-      - name: Ensure label and add to issue
+      - name: Check checkbox and add label
         uses: actions/github-script@v7
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const issue_number = context.payload.issue.number;
-            
-            const label = 'gssoc\'26';
-            const color = '5B1E78'; 
-            const description = 'Under GirlScript Summer of Code 2026';
-            
+            const issue = context.payload.issue;
+            const issue_number = issue.number;
+
+            const body = issue.body || "";
+
+            const label = "gssoc'26";
+            const color = "5B1E78";
+            const description = "Under GirlScript Summer of Code 2026";
+
+            // Check if checkbox is ticked
+            const isChecked = body.includes("- [x] I am a GSSoC'26 contributor");
+
+            if (!isChecked) {
+              console.log("Checkbox not checked. Skipping label.");
+              return;
+            }
+
+            // Ensure label exists
             try {
-              await github.rest.issues.updateLabel({
+              await github.rest.issues.getLabel({
                 owner,
                 repo,
-                name: label,
-                new_name: label,
-                color,
-                description
+                name: label
               });
             } catch (err) {
               if (err.status === 404) {
-                try {
-                  await github.rest.issues.createLabel({
-                    owner,
-                    repo,
-                    name: label,
-                    color,
-                    description
-                  });
-                } catch (createErr) {
-                  if (createErr.status !== 422) {
-                    throw createErr;
-                  }
-                }
-              } else {
-                throw err;
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label,
+                  color,
+                  description
+                });
               }
             }
-            
+
+            // Add label
             await github.rest.issues.addLabels({
               owner,
               repo,

--- a/.github/workflows/gssoc.yml
+++ b/.github/workflows/gssoc.yml
@@ -1,0 +1,60 @@
+name: Label new issues with gssoc'26
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-gssoc-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Ensure label and add to issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            
+            const label = 'gssoc\'26';
+            const color = '5B1E78'; 
+            const description = 'Under GirlScript Summer of Code 2026';
+            
+            try {
+              await github.rest.issues.updateLabel({
+                owner,
+                repo,
+                name: label,
+                new_name: label,
+                color,
+                description
+              });
+            } catch (err) {
+              if (err.status === 404) {
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label,
+                    color,
+                    description
+                  });
+                } catch (createErr) {
+                  if (createErr.status !== 422) {
+                    throw createErr;
+                  }
+                }
+              } else {
+                throw err;
+              }
+            }
+            
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [label]
+            });

--- a/.github/workflows/pull-request-gssoc-approve.yml
+++ b/.github/workflows/pull-request-gssoc-approve.yml
@@ -1,0 +1,42 @@
+name: Auto approve GSSOC PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  approve-gssoc:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+
+    steps:
+      - name: Check contributor and label PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const username = pr.user.login;
+
+            const label = "gssoc:approved";
+
+            // Get issues created by this user
+            const issues = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} type:issue author:${username} label:"gssoc'26"`
+            });
+
+            if (issues.data.total_count > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: [label]
+              });
+
+              console.log("PR labeled as gssoc:approved");
+            } else {
+              console.log("User has no GSSOC issue.");
+            }

--- a/.github/workflows/pull-request-gssoc-approve.yml
+++ b/.github/workflows/pull-request-gssoc-approve.yml
@@ -2,7 +2,7 @@ name: Auto approve GSSOC PRs
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited]
 
 jobs:
   approve-gssoc:
@@ -12,23 +12,39 @@ jobs:
       issues: read
 
     steps:
-      - name: Check contributor and label PR
+      - name: Check linked issue and label PR
         uses: actions/github-script@v7
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pr = context.payload.pull_request;
-            const username = pr.user.login;
+
+            const body = pr.body || "";
 
             const label = "gssoc:approved";
 
-            // Get issues created by this user
-            const issues = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${owner}/${repo} type:issue author:${username} label:"gssoc'26"`
+            // Extract issue number from PR body (Fixes #123)
+            const match = body.match(/(?:fixes|closes|resolves)\s+#(\d+)/i);
+
+            if (!match) {
+              console.log("No linked issue found in PR.");
+              return;
+            }
+
+            const issue_number = parseInt(match[1]);
+
+            // Fetch issue details
+            const issue = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number
             });
 
-            if (issues.data.total_count > 0) {
+            const labels = issue.data.labels.map(l => l.name);
+
+            // Check if issue has gssoc label
+            if (labels.includes("gssoc'26")) {
               await github.rest.issues.addLabels({
                 owner,
                 repo,
@@ -36,7 +52,7 @@ jobs:
                 labels: [label]
               });
 
-              console.log("PR labeled as gssoc:approved");
+              console.log("PR approved for GSSOC");
             } else {
-              console.log("User has no GSSOC issue.");
+              console.log("Linked issue is not GSSOC.");
             }


### PR DESCRIPTION
## Description
Added a GitHub Action workflow to automatically assign a <code>gssoc'26</code> label to the new issues during this GSSoC'26 period.

<br/>

## Related Issues

- Closes #1511 

## Additional Notes
@mdazfar2 Please review this PR. I cannot test this on my side as I have a forked repository.
