### PR TITLE
fix: reposition testimonial carousel arrows to prevent content overlap (#1531)

### DIFF
--- a/website3.0/components/Testmonial.jsx
+++ b/website3.0/components/Testmonial.jsx
@@ -154,7 +154,7 @@ const Testimonial = ({ theme }) => {
                     {currentIndex !== 1 && (
                         <button
                             onClick={prevReview}
-                            className="absolute top-1/2 -left-4 transform -translate-y-1/2 rounded-full p-2 shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors duration-200 hover:shadow-lg ml-1 bg-white hover:bg-gray-100"
+                            className="absolute top-1/2 left-2 transform -translate-y-1/2 rounded-full p-2 shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors duration-200 hover:shadow-lg z-10 bg-white hover:bg-gray-100"
                         >
                             <ChevronLeft className="w-6 h-6 text-gray-600" />
                         </button>
@@ -162,7 +162,7 @@ const Testimonial = ({ theme }) => {
                     {currentIndex !== infiniteReviews.length - 2 && (
                         <button
                             onClick={nextReview}
-                            className="absolute top-1/2 -right-4 transform -translate-y-1/2 rounded-full p-2 shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors duration-200 hover:shadow-lg mr-1 bg-white hover:bg-gray-100"
+                            className="absolute top-1/2 right-2 transform -translate-y-1/2 rounded-full p-2 shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors duration-200 hover:shadow-lg z-10 bg-white hover:bg-gray-100"
                         >
                             <ChevronRight className="w-6 h-6 text-gray-600" />
                         </button>


### PR DESCRIPTION
## Summary

This PR fixes issue #1531 where the testimonial carousel navigation arrows overlapped the card content, causing a broken layout and obstructed text.

## Changes Made

- Changed left arrow from \-left-4\ to \left-2\ (positioned inside container edge)
- Changed right arrow from \-right-4\ to \ight-2\
- Added \z-10\ to both buttons for proper stacking
- Removed unused \ml-1\/\mr-1\ margin utilities