### PR TITLE
docs: fix grammatical error in contributing guidelines section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The goal of our project is to empower DevOps professionals by providing a compre
 
 We welcome contributors from the Developers & DevOps community to enrich HelpOps-Hub and make it even more valuable for everyone. Please follow our [CONTRIBUTING guidelines](https://github.com/mdazfar2/HelpOps-Hub/blob/main/CONTRIBUTING.md) for the following:-
 
-***Want to contribute to our website you must have to read [CONTRIBUTING guidelines](https://github.com/mdazfar2/HelpOps-Hub/blob/main/CONTRIBUTING.md).***
+***If you want to contribute to our website, you must first read the [CONTRIBUTING guidelines](https://github.com/mdazfar2/HelpOps-Hub/blob/main/CONTRIBUTING.md).***
 - Setup HelpOps-Hub on your local machine
 - Append new Documentation of Installation or anything
 - Append new DevOps Tools


### PR DESCRIPTION
Description
This pull request improves the Want to Contribute? section inside the primary README.md file by fixing a grammatical tautology and improving sentence structure. Specifically, it refactors the phrasing from ***Want to contribute to our website you must have to read...*** to ***If you want to contribute to our website, you must first read the...***. This correction enhances the professionalism of the repository and provides clearer instructions for incoming open-source contributors.

Related Issues
Closes #1548

Screenshots / videos (if applicable)
No visual UI layout components or routing scripts were altered in this repository documentation patch.